### PR TITLE
correct usage of paper-icon-item

### DIFF
--- a/widgets-todo-list/src/main/java/org/gwtproject/tutorial/client/Main.ui.xml
+++ b/widgets-todo-list/src/main/java/org/gwtproject/tutorial/client/Main.ui.xml
@@ -38,22 +38,22 @@
         <p:PaperHeaderPanel mode="seamed">
           <p:PaperToolbar addStyleNames="{style.toolbar}" />
           <p:PaperIconItem ui:field="menuClearAll">
-            <i:IronIcon icon="delete" />
+            <i:IronIcon icon="delete" item-icon/>
             <div>Clear All</div>
             <p:PaperRipple />
           </p:PaperIconItem>
           <p:PaperIconItem ui:field="menuClearDone">
-            <i:IronIcon icon="clear" />
+            <i:IronIcon icon="clear" item-icon/>
             <div>Clear Done</div>
             <p:PaperRipple />
           </p:PaperIconItem>
           <p:PaperIconItem ui:field="menuSettings">
-            <i:IronIcon icon="settings" />
+            <i:IronIcon icon="settings" item-icon/>
             <div>Settings</div>
             <p:PaperRipple />
           </p:PaperIconItem>
           <p:PaperIconItem ui:field="menuAbout">
-            <i:IronIcon icon="help" />
+            <i:IronIcon icon="help" item-icon/>
             <div>About</div>
             <p:PaperRipple />
           </p:PaperIconItem>


### PR DESCRIPTION
by adding "item-icon" it specifies, that the icon is used inside the paper-item. that allows for example the expected correct side alignment of the icons, which still works if a description(for example "Clear All") is longer.

example of how it should look like: http://s18.postimg.org/wy5s2vot5/gwtpoly.png

check out the polymer elements side for reference:
https://github.com/PolymerElements/paper-item/blob/master/demo/index.html#L102
https://elements.polymer-project.org/elements/paper-item?view=demo:demo/index.html&active=paper-item

so this:

```
<paper-icon-item role="listitem" class="x-scope paper-icon-item-0">
<div class="content-icon layout horizontal center style-scope paper-icon-item" id="contentIcon">

</div>
<iron-icon class="x-scope iron-icon-0">...</iron-icon> 
<div>Clear All</div> 
<paper-ripple>
<div id="background" class="style-scope paper-ripple" style="opacity: 0.009872;"></div>
<div id="waves" class="style-scope paper-ripple"></div>
</paper-ripple>
</paper-icon-item>
```

becomes this:

```
<paper-icon-item class="x-scope paper-icon-item-0" role="listitem">
<div id="contentIcon" class="content-icon layout horizontal center style-scope paper-icon-item">
    <iron-icon class="x-scope iron-icon-0"></iron-icon> 
</div>   
<div>Clear All</div> 
<paper-ripple>
<div class="style-scope paper-ripple" id="background"></div>
<div class="style-scope paper-ripple" id="waves"></div>
</paper-ripple>
</paper-icon-item>
```
